### PR TITLE
Minor README Tweaks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,11 +6,11 @@
 > This plugin requires the [AcodeX-Server](https://github.com/bajrangCoder/AcodeX-server) NodeJS package to be installed and running on [Termux](https://termux.dev).
 
 > **Note**
-> _For old AcodeX users:_
-> Before installing, update your acodeX-server to version `v2.1.0` by running the following command in Termux:<br />
+> **For old AcodeX users:**
+> Before installing, update your [AcodeX-Server](https://github.com/bajrangCoder/AcodeX-server) to version `v2.1.0` by running the following command in Termux:<br />
 > <pre>npm update -g acodex-server</pre>
 
-[AcodeX](https://github.com/bajrangCoder/acode-plugin-acodex) is a powerful plugin for the Acode app that enhances your coding productivity by adding terminal support. With AcodeX, you can execute terminal commands directly within the Acode app, eliminating the need to switch between apps for coding and terminal access.
+[AcodeX](https://github.com/bajrangCoder/acode-plugin-acodex) is a powerful plugin for [Acode](https://acode.foxdebug.com/) that enhances your coding productivity by adding in-app Termux terminal integration. With AcodeX, you can execute terminal commands directly from within the Acode app, eliminating the need to switch between apps for coding and terminal access.
 
 > **Note**
 > When starting a new terminal, be sure to adjust the terminal panel according to your screen. You can drag it to your desired position, and it will automatically adjust the columns and rows according to your screen size.
@@ -19,7 +19,7 @@
 
 <details>
     <summary>
-        Updates v2.1.2
+        <h3 style="display:inline">Updates v2.1.2</h3>
     </summary>
     <ul>
         <li>Improved readme</li>

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 > **Note**
 > _For old AcodeX users:_
 > Before installing, update your acodeX-server to version `v2.1.0` by running the following command in Termux:<br />
-> `npm update -g acodex-server`
+> <pre>npm update -g acodex-server</pre>
 
 [AcodeX](https://github.com/bajrangCoder/acode-plugin-acodex) is a powerful plugin for the Acode app that enhances your coding productivity by adding terminal support. With AcodeX, you can execute terminal commands directly within the Acode app, eliminating the need to switch between apps for coding and terminal access.
 

--- a/readme.md
+++ b/readme.md
@@ -2,11 +2,16 @@
 
 [![Buy Me A Coffee](https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png)](https://www.buymeacoffee.com/bajrangCoder)
 
-> **Note**: Before installing, update your acodeX-server to version `v2.1.0` by running the following command in Termux: `npm update -g acodex-server` (**Note:** _Only for old AcodeX user_)
+> **Warning**
+> This plugin requires the [AcodeX-Server](https://github.com/bajrangCoder/AcodeX-server) NodeJS package to be installed and running on [Termux](https://termux.dev).
+
+> **Note**
+> Before installing, update your acodeX-server to version `v2.1.0` by running the following command in Termux: `npm update -g acodex-server` (**Note:** _Only for old AcodeX user_)
 
 [AcodeX](https://github.com/bajrangCoder/acode-plugin-acodex) is a powerful plugin for the Acode app that enhances your coding productivity by adding terminal support. With AcodeX, you can execute terminal commands directly within the Acode app, eliminating the need to switch between apps for coding and terminal access.
 
-> **Note**: When starting a new terminal, be sure to adjust the terminal panel according to your screen. You can drag it to your desired position, and it will automatically adjust the columns and rows according to your screen size.
+> **Note**
+> When starting a new terminal, be sure to adjust the terminal panel according to your screen. You can drag it to your desired position, and it will automatically adjust the columns and rows according to your screen size.
 
 ### Support this project with your small contribution - [Click Me 💗](https://www.buymeacoffee.com/bajrangCoder)
 

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,9 @@
 > This plugin requires the [AcodeX-Server](https://github.com/bajrangCoder/AcodeX-server) NodeJS package to be installed and running on [Termux](https://termux.dev).
 
 > **Note**
-> Before installing, update your acodeX-server to version `v2.1.0` by running the following command in Termux: `npm update -g acodex-server` (**Note:** _Only for old AcodeX user_)
+> _For old AcodeX users:_
+> Before installing, update your acodeX-server to version `v2.1.0` by running the following command in Termux:<br />
+> `npm update -g acodex-server`
 
 [AcodeX](https://github.com/bajrangCoder/acode-plugin-acodex) is a powerful plugin for the Acode app that enhances your coding productivity by adding terminal support. With AcodeX, you can execute terminal commands directly within the Acode app, eliminating the need to switch between apps for coding and terminal access.
 


### PR DESCRIPTION
## Overview

The most significant change I made was to the `> **Note**` blocks so that they would display using their unique formatting (see [Note & Warning Blocks](#note_and_warning_blocks)).

I also added a **Warning** block that informs users they need to setup the [AcodeX-Server](https://github.com/bajrangCoder/AcodeX-server) in order to use **AcodeX**

The rest of the changes are just slight tweaks to wording and stuff to add clarity.

---


## Note and Warning Blocks
**Note** and **Warning** blocks that include a colon `:`, like what you had originally, won't be formatted correctly. 


### ❌ Incorrect Formatting
#### Raw Markdown Code:
```md
> **Note:**
> Note block content.

> **Warning:**
> Warning block content.
```

#### Output (GitHub):
> **Note:**
> Note block content.

> **Warning:**
> Warning block content.




<br />

### ✅ Correct Formatting
#### Raw Markdown Code:
```md
> **Note**
> Note block content.

> **Warning**
> Warning block content.
```


#### Output (GitHub):
> **Note**
> Note block content.

> **Warning**
> Warning block content. 
