### PR TITLE
Fix Typographical Error in Documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@
 
 - **User-Friendly Terminal**: AcodeX provides a seamless terminal experience within Acode. You can open the terminal panel with a simple `Ctrl+K` shortcut or by searching for "Open Terminal" in the command palette.
 
-- **Integrated AI**: if you don't know any command, just ask the ai and ai will weite it
+- **Integrated AI**: if you don't know any command, just ask the ai and ai will write ✍️ it
 
 - **Enhanced Productivity**: With AcodeX, developers can save time by executing commands directly within Acode, eliminating the need to switch between multiple applications.
 


### PR DESCRIPTION
This pull request addresses a minor typographical error found in the documentation. The term "weite" has been corrected to "write" to enhance clarity and ensure accurate communication.

[https://github.com/bajrangCoder/acode-plugin-acodex/blob/main/readme.md

![IMG_20240925_151614](https://github.com/user-attachments/assets/a1532877-4990-46ea-ad2e-f3ef88792d14)


Issue reference:https://github.com/bajrangCoder/acode-plugin-acodex/pull/71/files
