### PR TITLE
Fix termux link in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 </p>
 
 > [!Warning]
-> This plugin requires the [axs](https://github.com/bajrangCoder/acodex_server) to be installed and running on [Termux](https://termux.dev) Or Directly use it with Acode's builtin terminal backend.
+> This plugin requires the [axs](https://github.com/bajrangCoder/acodex_server) to be installed and running on [Termux](https://termux.dev) or Directly use it with Acode's builtin terminal backend.
 
 [AcodeX](https://github.com/bajrangCoder/acode-plugin-acodex) is a powerful and AI integrated terminal plugin with **150k++ downloads** for [Acode](https://acode.foxdebug.com/) that enhances your coding productivity by adding in-app Termux terminal integration. With AcodeX, you can execute terminal commands directly from within the Acode app, eliminating the need to switch between apps for coding and terminal access. AcodeX has almost every terminal feature and also it is more feature rich when it comes to rendering things compared termux etc (Thanks to xtermjs)
 


### PR DESCRIPTION
Corrected the termux link formatting in warning message about the axs plugin installation for clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README warning text for Termux: fixed URL/formatting and clarified that Termux is required, and can also be used directly with Acode’s built‑in terminal backend.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->